### PR TITLE
Prevent duplicate item

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,8 +28,7 @@ function App() {
 
   function saveToken(e) {
     e.preventDefault();
-    //const token = getToken();
-    const token = 'three word token'; // SM TODO- Get rid of this line
+    const token = getToken();
     localStorage.setItem('token', token);
     setUserToken(token);
   }
@@ -49,8 +48,6 @@ function App() {
           // if there are results and an id property exists
           if (!querySnapshot.empty && 'id' in querySnapshot.docs[0]) {
             setListId(querySnapshot.docs[0].id); // save the list id for later
-            console.log(token);
-            console.log(listId);
           }
         })
         .catch((error) => {

--- a/src/App.js
+++ b/src/App.js
@@ -28,7 +28,8 @@ function App() {
 
   function saveToken(e) {
     e.preventDefault();
-    const token = getToken();
+    //const token = getToken();
+    const token = 'three word token'; // SM TODO- Get rid of this line
     localStorage.setItem('token', token);
     setUserToken(token);
   }
@@ -48,6 +49,8 @@ function App() {
           // if there are results and an id property exists
           if (!querySnapshot.empty && 'id' in querySnapshot.docs[0]) {
             setListId(querySnapshot.docs[0].id); // save the list id for later
+            console.log(token);
+            console.log(listId);
           }
         })
         .catch((error) => {

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -14,7 +14,14 @@ const AddItemForm = ({ listId }) => {
 
   const isItemDuplicate = (item, array) => {
     // TODO: Potential to remove all spaces in item and items in array
-    const itemToCompare = item.toLowerCase().trim(); // transform and remove leading and/or trailing whitespace
+
+    // .replace's remove punctuation, then remove extra spaces from removing punctuation
+    // .trim() to remove leading and/or trailing whitespace (must be last)
+    const itemToCompare = item
+      .toLowerCase()
+      .replace(/[.,\/#!$%^&*;:{}=\-_`~()@[\]|<>+'"/?]/g, '')
+      .replace(/\s{2,}/g, ' ')
+      .trim();
 
     // if .indexOf returns -1, the item does not exist in array, aka it's not a duplicate, aka false
     return array.indexOf(itemToCompare) === -1 ? false : true;
@@ -22,7 +29,7 @@ const AddItemForm = ({ listId }) => {
 
   const addItemToDatabase = async () => {
     const newItem = {
-      ...formValues,
+      itemName: formValues.itemName.trim(), // remove extra whitespace from itemName to keep data clean
       purchaseInterval: Number(formValues.purchaseInterval),
       lastPurchaseDate: null,
       numberOfPurchases: 0,

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -7,10 +7,10 @@ const AddItemForm = ({ listId }) => {
     purchaseInterval: '7',
   };
 
-  const defaultInputMessage = '';
+  const defaultErrorMessage = '';
 
   const [formValues, setFormValues] = useState(defaultFormValues);
-  const [inputMessage, setInputMessage] = useState(defaultInputMessage);
+  const [errorMessage, setErrorMessage] = useState(defaultErrorMessage);
 
   // used when comparing entered item and array of db items for duplicates
   const normalizeInput = (item) => {
@@ -49,7 +49,7 @@ const AddItemForm = ({ listId }) => {
 
   // generic function updates formValues state for any of the below form inputs
   const handleChange = (event) => {
-    setInputMessage(defaultInputMessage); // if input field changes, reset error message
+    setErrorMessage(defaultErrorMessage); // if input field changes, reset error message
 
     const inputName = event.target.name;
     setFormValues({ ...formValues, [inputName]: event.target.value });
@@ -78,7 +78,7 @@ const AddItemForm = ({ listId }) => {
 
           // if item exists, show error message, otherwise, continue with adding to database
           if (duplicateResult === true) {
-            setInputMessage('Item already exists in Shopping List');
+            setErrorMessage('Item already exists in Shopping List');
           } else {
             addItemToDatabase();
           }
@@ -101,13 +101,13 @@ const AddItemForm = ({ listId }) => {
         type="text"
         id="itemName"
         name="itemName"
-        aria-describedby="itemNameMessage"
+        aria-describedby="itemErrorMessage"
         value={formValues.itemName}
         onChange={handleChange}
         maxLength="100"
         required
       />
-      <span id="itemNameMessage">{inputMessage}</span>
+      <span id="itemErrorMessage">{errorMessage}</span>
 
       <fieldset>
         <legend>How soon will you buy this again?</legend>

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -58,8 +58,6 @@ const AddItemForm = ({ listId }) => {
   };
 
   const isItemDuplicate = (item, array) => {
-    // TODO: Potential to remove all spaces in item and items in array
-
     const itemToCompare = normalizeInput(item);
     const arrayToCompare = array.map((dbItem) => normalizeInput(dbItem));
 
@@ -71,8 +69,8 @@ const AddItemForm = ({ listId }) => {
   const normalizeInput = (item) => {
     return item
       .toLowerCase()
-      .replace(/[.,/#!$%^&*;:{}=\-_`~()@[\]|<>+'"/?]/g, '') // remove punctuation
-      .replace(/\s{2,}/g, ' ') // remove extra spaces from removing punctuation
+      .replace(/\W/g, '') // remove non-word characters aka remove punctuation
+      .replace(/ /g, '') // remove spaces
       .trim(); // remove leading and trailing whitespace (trim must be last)
   };
 

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -35,18 +35,13 @@ const AddItemForm = ({ listId }) => {
         .collection(`lists/${listId}/items`)
         .get()
         .then(async (querySnapshot) => {
-          // create array (dbItemArray) by returning itemNames from Firestore response (querySnapshot)
-          let dbItemArray = querySnapshot.docs.map((doc) => {
-            return doc.data().itemName;
-          });
-
-          const duplicateResult = isItemDuplicate(
-            formValues.itemName,
-            dbItemArray,
+          // create array of normalized item names from Firestore response (querySnapshot)
+          const dbItemArray = querySnapshot.docs.map((doc) =>
+            normalizeInput(doc.data().itemName),
           );
 
           // if item exists, show error message, otherwise, continue with adding to database
-          if (duplicateResult === true) {
+          if (dbItemArray.includes(normalizeInput(formValues.itemName))) {
             setErrorMessage('Item already exists in Shopping List');
           } else {
             addItemToDatabase();
@@ -57,21 +52,9 @@ const AddItemForm = ({ listId }) => {
     }
   };
 
-  const isItemDuplicate = (item, array) => {
-    const itemToCompare = normalizeInput(item);
-    const arrayToCompare = array.map((dbItem) => normalizeInput(dbItem));
-
-    // if .indexOf returns -1, the item does not exist in array, aka it's not a duplicate, aka false
-    return arrayToCompare.indexOf(itemToCompare) === -1 ? false : true;
-  };
-
   // used when comparing entered item and array of db items for duplicates
   const normalizeInput = (item) => {
-    return item
-      .toLowerCase()
-      .replace(/\W/g, '') // remove non-word characters aka remove punctuation
-      .replace(/ /g, '') // remove spaces
-      .trim(); // remove leading and trailing whitespace (trim must be last)
+    return item.toLowerCase().replace(/\W/g, ''); // remove non-word characters aka remove punctuation and all spaces
   };
 
   const addItemToDatabase = async () => {

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { db } from '../../lib/firebase.js';
 
 const AddItemForm = ({ listId }) => {
+  /** Default Values **/
   const defaultFormValues = {
     itemName: '',
     purchaseInterval: '7',
@@ -9,43 +10,11 @@ const AddItemForm = ({ listId }) => {
 
   const defaultErrorMessage = '';
 
+  /** State **/
   const [formValues, setFormValues] = useState(defaultFormValues);
   const [errorMessage, setErrorMessage] = useState(defaultErrorMessage);
 
-  // used when comparing entered item and array of db items for duplicates
-  const normalizeInput = (item) => {
-    return item
-      .toLowerCase()
-      .replace(/[.,/#!$%^&*;:{}=\-_`~()@[\]|<>+'"/?]/g, '') // remove punctuation
-      .replace(/\s{2,}/g, ' ') // remove extra spaces from removing punctuation
-      .trim(); // remove leading and trailing whitespace (trim must be last)
-  };
-
-  const isItemDuplicate = (item, array) => {
-    // TODO: Potential to remove all spaces in item and items in array
-
-    const itemToCompare = normalizeInput(item);
-    const arrayToCompare = array.map((dbItem) => normalizeInput(dbItem));
-
-    // if .indexOf returns -1, the item does not exist in array, aka it's not a duplicate, aka false
-    return arrayToCompare.indexOf(itemToCompare) === -1 ? false : true;
-  };
-
-  const addItemToDatabase = async () => {
-    const newItem = {
-      itemName: formValues.itemName.trim(), // remove extra whitespace from itemName to keep data clean
-      purchaseInterval: Number(formValues.purchaseInterval),
-      lastPurchaseDate: null,
-      numberOfPurchases: 0,
-    };
-
-    try {
-      await db.collection(`lists/${listId}/items`).add(newItem); // add item to Firestore database
-      setFormValues(defaultFormValues); // after saving to database, reset form values to defaults
-    } catch (err) {
-      console.log(err);
-    }
-  };
+  /** Functions **/
 
   // generic function updates formValues state for any of the below form inputs
   const handleChange = (event) => {
@@ -83,6 +52,41 @@ const AddItemForm = ({ listId }) => {
             addItemToDatabase();
           }
         });
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const isItemDuplicate = (item, array) => {
+    // TODO: Potential to remove all spaces in item and items in array
+
+    const itemToCompare = normalizeInput(item);
+    const arrayToCompare = array.map((dbItem) => normalizeInput(dbItem));
+
+    // if .indexOf returns -1, the item does not exist in array, aka it's not a duplicate, aka false
+    return arrayToCompare.indexOf(itemToCompare) === -1 ? false : true;
+  };
+
+  // used when comparing entered item and array of db items for duplicates
+  const normalizeInput = (item) => {
+    return item
+      .toLowerCase()
+      .replace(/[.,/#!$%^&*;:{}=\-_`~()@[\]|<>+'"/?]/g, '') // remove punctuation
+      .replace(/\s{2,}/g, ' ') // remove extra spaces from removing punctuation
+      .trim(); // remove leading and trailing whitespace (trim must be last)
+  };
+
+  const addItemToDatabase = async () => {
+    const newItem = {
+      itemName: formValues.itemName.trim(), // remove extra whitespace from itemName to keep data clean
+      purchaseInterval: Number(formValues.purchaseInterval),
+      lastPurchaseDate: null,
+      numberOfPurchases: 0,
+    };
+
+    try {
+      await db.collection(`lists/${listId}/items`).add(newItem); // add item to Firestore database
+      setFormValues(defaultFormValues); // after saving to database, reset form values to defaults
     } catch (err) {
       console.log(err);
     }

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -12,19 +12,23 @@ const AddItemForm = ({ listId }) => {
   const [formValues, setFormValues] = useState(defaultFormValues);
   const [inputMessage, setInputMessage] = useState(defaultInputMessage);
 
+  // used when comparing entered item and array of db items for duplicates
+  const normalizeInput = (item) => {
+    return item
+      .toLowerCase()
+      .replace(/[.,/#!$%^&*;:{}=\-_`~()@[\]|<>+'"/?]/g, '') // remove punctuation
+      .replace(/\s{2,}/g, ' ') // remove extra spaces from removing punctuation
+      .trim(); // remove leading and trailing whitespace (trim must be last)
+  };
+
   const isItemDuplicate = (item, array) => {
     // TODO: Potential to remove all spaces in item and items in array
 
-    // .replace's remove punctuation, then remove extra spaces from removing punctuation
-    // .trim() to remove leading and/or trailing whitespace (must be last)
-    const itemToCompare = item
-      .toLowerCase()
-      .replace(/[.,\/#!$%^&*;:{}=\-_`~()@[\]|<>+'"/?]/g, '')
-      .replace(/\s{2,}/g, ' ')
-      .trim();
+    const itemToCompare = normalizeInput(item);
+    const arrayToCompare = array.map((dbItem) => normalizeInput(dbItem));
 
     // if .indexOf returns -1, the item does not exist in array, aka it's not a duplicate, aka false
-    return array.indexOf(itemToCompare) === -1 ? false : true;
+    return arrayToCompare.indexOf(itemToCompare) === -1 ? false : true;
   };
 
   const addItemToDatabase = async () => {

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { db } from '../../lib/firebase.js';
-import { useCollection } from 'react-firebase-hooks/firestore';
 
 const AddItemForm = ({ listId }) => {
   const defaultFormValues = {
@@ -8,8 +7,10 @@ const AddItemForm = ({ listId }) => {
     purchaseInterval: '7',
   };
 
+  const defaultInputMessage = '';
+
   const [formValues, setFormValues] = useState(defaultFormValues);
-  const [inputMessage, setInputMessage] = useState('Sheila is great');
+  const [inputMessage, setInputMessage] = useState(defaultInputMessage);
 
   const isItemDuplicate = (item, array) => {
     // TODO: Potential to remove all spaces in item and items in array
@@ -37,6 +38,8 @@ const AddItemForm = ({ listId }) => {
 
   // generic function updates formValues state for any of the below form inputs
   const handleChange = (event) => {
+    setInputMessage(defaultInputMessage); // if input field changes, reset error message
+
     const inputName = event.target.name;
     setFormValues({ ...formValues, [inputName]: event.target.value });
   };

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -11,6 +11,14 @@ const AddItemForm = ({ listId }) => {
   const [formValues, setFormValues] = useState(defaultFormValues);
   const [inputMessage, setInputMessage] = useState('Sheila is great');
 
+  const isItemDuplicate = (item, array) => {
+    // TODO: Potential to remove all spaces in item and items in array
+    const itemToCompare = item.toLowerCase().trim(); // transform and remove leading and/or trailing whitespace
+
+    // if .indexOf returns -1, the item does not exist in array, aka it's not a duplicate, aka false
+    return array.indexOf(itemToCompare) === -1 ? false : true;
+  };
+
   // generic function updates formValues state for any of the below form inputs
   const handleChange = (event) => {
     const inputName = event.target.name;
@@ -21,9 +29,27 @@ const AddItemForm = ({ listId }) => {
   const handleSubmit = async (event) => {
     event.preventDefault();
 
-    // on form submit, check if itemName already exists in Firestore
+    // check if itemName already exists in Firestore
+    try {
+      // get array of listItems from Firestore
+      await db
+        .collection(`lists/${listId}/items`)
+        .get()
+        .then((querySnapshot) => {
+          // create array (dbItemArray) by returning itemNames from Firestore response (querySnapshot)
+          let dbItemArray = querySnapshot.docs.map((doc) => {
+            return doc.data().itemName;
+          });
 
-    // get array of listItems from Firestore and compare against itemName input value
+          const duplicateResult = isItemDuplicate(
+            formValues.itemName,
+            dbItemArray,
+          );
+          console.log(duplicateResult);
+        });
+    } catch (err) {
+      console.log(err);
+    }
 
     // if matches, show error message
 

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { db } from '../../lib/firebase.js';
+import { useCollection } from 'react-firebase-hooks/firestore';
 
 const AddItemForm = ({ listId }) => {
   const defaultFormValues = {
@@ -8,6 +9,7 @@ const AddItemForm = ({ listId }) => {
   };
 
   const [formValues, setFormValues] = useState(defaultFormValues);
+  const [inputMessage, setInputMessage] = useState('Sheila is great');
 
   // generic function updates formValues state for any of the below form inputs
   const handleChange = (event) => {
@@ -18,6 +20,14 @@ const AddItemForm = ({ listId }) => {
   // on form submit, add user input and other default values to database
   const handleSubmit = async (event) => {
     event.preventDefault();
+
+    // on form submit, check if itemName already exists in Firestore
+
+    // get array of listItems from Firestore and compare against itemName input value
+
+    // if matches, show error message
+
+    // otherwise, continue with adding to database (below)
 
     const newItem = {
       ...formValues,
@@ -47,11 +57,13 @@ const AddItemForm = ({ listId }) => {
         type="text"
         id="itemName"
         name="itemName"
+        aria-describedby="itemNameMessage"
         value={formValues.itemName}
         onChange={handleChange}
         maxLength="100"
         required
       />
+      <span id="itemNameMessage">{inputMessage}</span>
 
       <fieldset>
         <legend>How soon will you buy this again?</legend>

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -8,17 +8,15 @@ const AddItemForm = ({ listId }) => {
     purchaseInterval: '7',
   };
 
-  const defaultErrorMessage = '';
-
   /** State **/
   const [formValues, setFormValues] = useState(defaultFormValues);
-  const [errorMessage, setErrorMessage] = useState(defaultErrorMessage);
+  const [errorMessage, setErrorMessage] = useState('');
 
   /** Functions **/
 
   // generic function updates formValues state for any of the below form inputs
   const handleChange = (event) => {
-    setErrorMessage(defaultErrorMessage); // if input field changes, reset error message
+    setErrorMessage(''); // if input field changes, reset error message
 
     const inputName = event.target.name;
     setFormValues({ ...formValues, [inputName]: event.target.value });
@@ -27,6 +25,8 @@ const AddItemForm = ({ listId }) => {
   // on form submit, add user input and other default values to database
   const handleSubmit = async (event) => {
     event.preventDefault();
+
+    setErrorMessage(''); // clear any old errors when the form is submitted for accessibility to provide feedback after 1st submission
 
     // check if itemName already exists in Firestore
     try {


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

When a user tries to add a new item, the AddItemForm retrieves the itemNames out of Firestore and compares against the itemName of the new item being entered. If they match, an error message displays under Item Name that this item already exists in the Shopping List.

Additional Notes: 
- We decided to prevent the user from, say, adding "jackfruit" and "jack fruit" by removing spaces. You can STILL add spaces and punctuation when you FIRST add an item to the database. However, when you try to add "jackfruit" AGAIN, it will remove spaces, which will prevent you from adding "jack fruit".
- We also decided to remove any spaces before and after what the user enters from being entered into the database in order to prevent issues in the database. We followed the Microsoft To-Do app in this practice. This also makes it easier to compare itemNames when checking for duplicates.
- We also did some grouping of variables/state/functions in the AddItemForm component. I think this is a practice we have all been following, but we codified it with comments.

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

Closes #6: As a user, I want to be alerted when I’m entering an item that is the same as something already on my list so I can avoid duplicate items

## Acceptance Criteria

- Show an error message if the user tries to submit a new item that has the exact same name as an existing item
- Show an error message if the user tries to submit a new item that has the same name as an existing item, where 
   capitalization has been normalized and punctuation has been removed
- The user’s original input should be what gets saved in the database

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

In the AddItemForm component, we added a new span under the Item Name input to display the duplicate error message. 

In the handleSubmit function, when the user hits Add Item, it runs the following new functionality:

- Gets array of listItems from Firestore (db.collection.get().then(querySnapshot))
- Checks new function - isItemDuplicate: Checks if the itemName being entered matches any of the itemName's from Firestore
- Which uses normalizeInput: Removes punctuation and spaces from the itemName being entered and does the same for the array of items out of Firestore
- If isItemDuplicate is true, then 'Item already exists in Shopping List' is setErrorMessage.
- If isItemDuplicate is false, then we addItemToDatabase - which is previous functionality that we moved into its own function

### Before

<!-- If UI feature, take provide screenshots -->

![image](https://user-images.githubusercontent.com/61371242/127589698-7ac328a9-9199-483c-9b11-b51bdeab53e0.png)


### After

<!-- If UI feature, take provide screenshots -->

![image](https://user-images.githubusercontent.com/61371242/127589722-ffaabc68-16df-4ae1-8834-c92348a9bcde.png)



## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

1. Pull down branch.
2. npm start
3. Add an item that does not yet exist in list.
4. Try adding an item that has the exact same name. The error will appear.
5. Try adding an item that has the same name but with punctuation in between the characters. (ex: honey and h@#$oney). The error will appear.
6. Try adding an item that has the same name but with spaces in between the characters (ex: jack fruit and jackfruit). The error will appear.


## To-Dos / Nice to Haves
Some things we'd like to do but didn't get a chance to get to:

- We noticed Issue #29 
- Make setErrorMessage for displaying the error message more generic so that if we were ever to add more input fields, it would still work.
