### PR TITLE
Check list items as purchased

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -67,3 +67,9 @@ BEM conventions we are using:
   font-size: 16px;
   margin: 0 0 20px 0;
 }
+
+.list-reset {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -108,7 +108,7 @@ const AddItemForm = ({ listId }) => {
         />
         <label
           htmlFor="soonOption"
-          className="add-item-form__label add-item-form__label_type_radio label"
+          className="add-item-form__label add-item-form__label_type_radio label label_check-radio"
         >
           Soon
         </label>
@@ -124,7 +124,7 @@ const AddItemForm = ({ listId }) => {
         />
         <label
           htmlFor="kindaSoonOption"
-          className="add-item-form__label add-item-form__label_type_radio label"
+          className="add-item-form__label add-item-form__label_type_radio label label_check-radio"
         >
           Kind of Soon
         </label>
@@ -140,7 +140,7 @@ const AddItemForm = ({ listId }) => {
         />
         <label
           htmlFor="notSoonOption"
-          className="add-item-form__label add-item-form__label_type_radio label"
+          className="add-item-form__label add-item-form__label_type_radio label label_check-radio"
         >
           Not Soon
         </label>

--- a/src/components/ShoppingList/ShoppingList.js
+++ b/src/components/ShoppingList/ShoppingList.js
@@ -1,3 +1,4 @@
+import firebase from 'firebase/app';
 import { db } from '../../lib/firebase.js';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import ShoppingListItem from '../ShoppingListItem/ShoppingListItem.js';
@@ -6,6 +7,21 @@ function ShoppingList({ listId }) {
   const [listItems, loading, error] = useCollection(
     db.collection(`lists/${listId}/items`).orderBy('purchaseInterval', 'asc'),
   );
+
+  const handleCheck = (e) => {
+    if (!e.target.checked) return; // don't do anything if the checkbox isn't checked
+
+    const itemId = e.target.value;
+    db.collection(`lists/${listId}/items`)
+      .doc(itemId)
+      .update({
+        lastPurchaseDate: firebase.firestore.FieldValue.serverTimestamp(),
+        numberOfPurchases: firebase.firestore.FieldValue.increment(1),
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
 
   return (
     <div className="shopping-list">
@@ -22,9 +38,15 @@ function ShoppingList({ listId }) {
       )}
 
       {!loading && listItems && (
-        <ul className="shopping-list__list">
+        <ul className="shopping-list__list list-reset">
           {listItems.docs.map((doc) => (
-            <ShoppingListItem key={doc.id} item={doc.data()} />
+            <ShoppingListItem
+              key={doc.id}
+              listId={listId}
+              itemId={doc.id}
+              item={doc.data()}
+              handleCheck={handleCheck}
+            />
           ))}
         </ul>
       )}

--- a/src/components/ShoppingList/ShoppingList.js
+++ b/src/components/ShoppingList/ShoppingList.js
@@ -9,8 +9,6 @@ function ShoppingList({ listId }) {
   );
 
   const handleCheck = (e) => {
-    if (!e.target.checked) return; // don't do anything if the checkbox isn't checked
-
     const itemId = e.target.value;
     db.collection(`lists/${listId}/items`)
       .doc(itemId)

--- a/src/components/ShoppingListItem/ShoppingListItem.js
+++ b/src/components/ShoppingListItem/ShoppingListItem.js
@@ -1,5 +1,36 @@
-const ShoppingListItem = ({ item }) => {
-  return <li className="shopping-list__item item">{item.itemName}</li>;
+import { db } from '../../lib/firebase.js';
+import { useState, useEffect } from 'react';
+
+import isUnder24hSincePurchased from '../../utils/isUnder24hSincePurchased.js';
+
+const ShoppingListItem = ({ listId, itemId, item }) => {
+  const [recentlyPurchased, setRecentlyPurchased] = useState(
+    isUnder24hSincePurchased(item.lastPurchaseDate),
+  );
+
+  // update whether item is recently purchased
+  useEffect(() => {
+    setRecentlyPurchased(isUnder24hSincePurchased(item.lastPurchaseDate));
+  }, [item.lastPurchaseDate]);
+
+  return (
+    <li className="shopping-list__item item">
+      <input
+        id={`item-${itemId}`}
+        value={itemId}
+        type="checkbox"
+        disabled={recentlyPurchased}
+        checked={recentlyPurchased}
+        className={`checkbox shopping-list__checkbox ${recentlyPurchased} ? 'checkbox_recently-purchased' : '' `}
+      />
+      <label
+        className="label label_check-radio shopping-list__label"
+        htmlFor={`item-${itemId}`}
+      >
+        {item.itemName}
+      </label>
+    </li>
+  );
 };
 
 export default ShoppingListItem;

--- a/src/components/ShoppingListItem/ShoppingListItem.js
+++ b/src/components/ShoppingListItem/ShoppingListItem.js
@@ -8,11 +8,7 @@ const ShoppingListItem = ({ listId, itemId, item, handleCheck }) => {
   // update whether item is recently purchased
   useEffect(() => {
     // make sure properties exist and are not null
-    if (
-      'lastPurchaseDate' in item &&
-      item.lastPurchaseDate &&
-      'seconds' in item.lastPurchaseDate
-    )
+    if (item?.lastPurchaseDate?.seconds)
       setRecentlyPurchased(
         isUnder24hSincePurchased(item.lastPurchaseDate.seconds),
       );

--- a/src/components/ShoppingListItem/ShoppingListItem.js
+++ b/src/components/ShoppingListItem/ShoppingListItem.js
@@ -1,17 +1,22 @@
-import { db } from '../../lib/firebase.js';
 import { useState, useEffect } from 'react';
 
 import isUnder24hSincePurchased from '../../utils/isUnder24hSincePurchased.js';
 
-const ShoppingListItem = ({ listId, itemId, item }) => {
-  const [recentlyPurchased, setRecentlyPurchased] = useState(
-    isUnder24hSincePurchased(item.lastPurchaseDate),
-  );
+const ShoppingListItem = ({ listId, itemId, item, handleCheck }) => {
+  const [recentlyPurchased, setRecentlyPurchased] = useState(false);
 
   // update whether item is recently purchased
   useEffect(() => {
-    setRecentlyPurchased(isUnder24hSincePurchased(item.lastPurchaseDate));
-  }, [item.lastPurchaseDate]);
+    // make sure properties exist and are not null
+    if (
+      'lastPurchaseDate' in item &&
+      item.lastPurchaseDate &&
+      'seconds' in item.lastPurchaseDate
+    )
+      setRecentlyPurchased(
+        isUnder24hSincePurchased(item.lastPurchaseDate.seconds),
+      );
+  }, [item]);
 
   return (
     <li className="shopping-list__item item">
@@ -22,6 +27,7 @@ const ShoppingListItem = ({ listId, itemId, item }) => {
         disabled={recentlyPurchased}
         checked={recentlyPurchased}
         className={`checkbox shopping-list__checkbox ${recentlyPurchased} ? 'checkbox_recently-purchased' : '' `}
+        onChange={handleCheck}
       />
       <label
         className="label label_check-radio shopping-list__label"

--- a/src/utils/isUnder24hSincePurchased.js
+++ b/src/utils/isUnder24hSincePurchased.js
@@ -1,0 +1,6 @@
+const isUnder24hSincePurchased = (lastPurchaseDate) => {
+  const now = Math.floor(new Date() / 1000); // unix timestamp of the current time (seconds)
+  return now - lastPurchaseDate < 24 * 60 * 60; // return boolean based on whether 24 hours has elapsed
+};
+
+export default isUnder24hSincePurchased;


### PR DESCRIPTION
## Description

This PR adds functionality to allow a user to check off items on their shopping list. We also prevent user's from checking an item twice within 24 hours. 

### ShoppingListItem component updates
We added a checkbox input and label for items. The component checks if the item was purchased within the last 24 hours using helper function `isUnder24hSincePurchased` to compare timestamps. While the purchase is recent, the checkbox is disabled.

### ShoppingList component updates
We added the `handleCheck` function to this component and passed it to the ShoppingListItem component to run onChange for any checkbox. `handleCheck` makes sure the checkbox is checked, and if so updates the associated item's Firestore document with a current timestamp for the lastPurchaseDate and increments the numberOfPurchases.

## Related Issue

Closes #8

## Acceptance Criteria

- [ ] User is able to tap a checkbox or similar UI element to mark an item in the list as purchased
- [ ] Item should be shown as checked for 24 hours after the purchase is made (i.e. we assume the user does not need to buy the item again for at least 1 day)

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before
![image](https://user-images.githubusercontent.com/67769490/127950674-e2354e1c-267c-48ed-96c6-7154423f5c8e.png)

### After
![image](https://user-images.githubusercontent.com/67769490/127948730-a3bdb542-6f06-4680-bc80-eb9e5db52e6d.png)

## Testing Steps / QA Criteria

1. Pull down this branch and check it out.
2. Run npm install if you don't have the dependencies installed yet.
3. Run npm start to start local server.
4. Once you have created a list, add some items and check them off.
5. Check Firestore database to verify the timestamp and number of purchases were updated correctly.
6. In Firestore, manipulate the lastPurchaseDate timestamp of an item to verify that you are able to check it off again 24 hours after lastPurchaseDate.

