### PR TITLE
Update purchase interval when checking off item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10565,6 +10565,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "luxon": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.0.2.tgz",
+      "integrity": "sha512-ZRioYLCgRHrtTORaZX1mx+jtxKtKuI5ZDvHNAmqpUzGqSrR+tL4FVLn/CUGMA3h0+AKD1MAxGI5GnCqR5txNqg=="
+    },
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "firebase": "^8.8.0",
+    "luxon": "^2.0.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-firebase-hooks": "^3.0.4",

--- a/src/App.css
+++ b/src/App.css
@@ -51,11 +51,25 @@ BEM conventions we are using:
 }
 
 .button {
-  font-size: 20px;
+  display: block;
   width: 100%;
   box-sizing: border-box;
+  text-align: center;
+  cursor: pointer;
+  text-decoration: none;
+  font-size: 20px;
+  line-height: 1;
   padding: 8px;
   margin: 10px 0;
+  border: 1px solid #888;
+  background: #eee;
+  border-radius: 3px;
+  color: #000;
+}
+
+.button:hover,
+.button:focus {
+  background: #ddd;
 }
 
 .error {

--- a/src/components/ShoppingList/ShoppingList.js
+++ b/src/components/ShoppingList/ShoppingList.js
@@ -3,6 +3,8 @@ import { db } from '../../lib/firebase.js';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import ShoppingListItem from '../ShoppingListItem/ShoppingListItem.js';
 import { useHistory } from 'react-router-dom';
+import calculateEstimate from '../../lib/estimates.js';
+import { DateTime } from 'luxon';
 
 function ShoppingList({ listId }) {
   let history = useHistory();
@@ -11,13 +13,52 @@ function ShoppingList({ listId }) {
     db.collection(`lists/${listId}/items`).orderBy('purchaseInterval', 'asc'),
   );
 
-  const handleCheck = (e) => {
-    const itemId = e.target.value;
+  /*
+   * Helper function to get the latest interval between purchases (takes Luxon date objects)
+   * Note: must account for the possibility an item hasn't been purchased, so lastPurchaseDate is null
+   **/
+  const getLatestInterval = (args) => {
+    const { lastPurchaseDate, newPurchaseDate, defaultInterval } = args;
+
+    if (lastPurchaseDate instanceof DateTime) {
+      // if lastPurchaseDate is a valid date, calculate the interval
+      const duration = newPurchaseDate.diff(lastPurchaseDate, ['days']);
+      return Math.round(duration.as('days'));
+    } else {
+      // otherwise, return the default value provided
+      return defaultInterval;
+    }
+  };
+
+  const checkAsPurchased = (itemId, item) => {
+    // convert lastPurchaseDate from firestore and JS current time to Luxon DateTime objects
+    const lastPurchaseDate = item.lastPurchaseDate?.seconds
+      ? DateTime.fromSeconds(item.lastPurchaseDate.seconds)
+      : null; // for new items, lastPurchaseDate will be null so keep it null
+    const newPurchaseDate = DateTime.fromMillis(Date.now());
+
+    /* since an interval can't be calculated when the lastPurchaseDate is null,
+     * we provide the saved purchaseInterval as a default (the user's initial estimate) */
+    const latestInterval = getLatestInterval({
+      lastPurchaseDate: lastPurchaseDate,
+      newPurchaseDate: newPurchaseDate,
+      defaultInterval: item.purchaseInterval,
+    });
+
+    const newPurchaseInterval = calculateEstimate(
+      item.purchaseInterval,
+      latestInterval,
+      item.numberOfPurchases,
+    );
+
     db.collection(`lists/${listId}/items`)
       .doc(itemId)
       .update({
-        lastPurchaseDate: firebase.firestore.FieldValue.serverTimestamp(),
+        lastPurchaseDate: firebase.firestore.Timestamp.fromMillis(
+          newPurchaseDate.toMillis(),
+        ),
         numberOfPurchases: firebase.firestore.FieldValue.increment(1),
+        purchaseInterval: newPurchaseInterval,
       })
       .catch((err) => {
         console.log(err);
@@ -47,7 +88,7 @@ function ShoppingList({ listId }) {
               listId={listId}
               itemId={doc.id}
               item={doc.data()}
-              handleCheck={handleCheck}
+              checkAsPurchased={checkAsPurchased}
             />
           ))}
         </ul>

--- a/src/components/ShoppingList/ShoppingList.js
+++ b/src/components/ShoppingList/ShoppingList.js
@@ -20,7 +20,10 @@ function ShoppingList({ listId }) {
   const getLatestInterval = (args) => {
     const { lastPurchaseDate, newPurchaseDate, defaultInterval } = args;
 
-    if (lastPurchaseDate instanceof DateTime) {
+    if (
+      lastPurchaseDate instanceof DateTime &&
+      newPurchaseDate instanceof DateTime
+    ) {
       // if lastPurchaseDate is a valid date, calculate the interval
       const duration = newPurchaseDate.diff(lastPurchaseDate, ['days']);
       return Math.round(duration.as('days'));

--- a/src/components/ShoppingList/ShoppingList.js
+++ b/src/components/ShoppingList/ShoppingList.js
@@ -2,13 +2,11 @@ import firebase from 'firebase/app';
 import { db } from '../../lib/firebase.js';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import ShoppingListItem from '../ShoppingListItem/ShoppingListItem.js';
-import { useHistory } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import calculateEstimate from '../../lib/estimates.js';
 import { DateTime } from 'luxon';
 
 function ShoppingList({ listId }) {
-  let history = useHistory();
-
   const [listItems, loading, error] = useCollection(
     db.collection(`lists/${listId}/items`).orderBy('purchaseInterval', 'asc'),
   );
@@ -54,18 +52,14 @@ function ShoppingList({ listId }) {
       });
   };
 
-  const handleClick = () => {
-    history.push('/add');
-  };
-
   const createListElement = () => {
     if (listItems.empty) {
       return (
         <>
           <p>Your shopping list is currently empty.</p>
-          <button className="button" type="button" onClick={handleClick}>
+          <NavLink to="/add" className="button">
             Add Item
-          </button>
+          </NavLink>
         </>
       );
     } else {

--- a/src/components/ShoppingListItem/ShoppingListItem.js
+++ b/src/components/ShoppingListItem/ShoppingListItem.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 
 import isUnder24hSincePurchased from '../../utils/isUnder24hSincePurchased.js';
 
-const ShoppingListItem = ({ listId, itemId, item, handleCheck }) => {
+const ShoppingListItem = ({ listId, itemId, item, checkAsPurchased }) => {
   const [recentlyPurchased, setRecentlyPurchased] = useState(false);
 
   // update whether item is recently purchased
@@ -23,7 +23,7 @@ const ShoppingListItem = ({ listId, itemId, item, handleCheck }) => {
         disabled={recentlyPurchased}
         checked={recentlyPurchased}
         className={`checkbox shopping-list__checkbox ${recentlyPurchased} ? 'checkbox_recently-purchased' : '' `}
-        onChange={handleCheck}
+        onChange={() => checkAsPurchased(itemId, item)}
       />
       <label
         className="label label_check-radio shopping-list__label"


### PR DESCRIPTION
<!-- _For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._ -->

## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

This PR adds functionality to save an updated estimated purchase interval whenever an item is purchased. We do this by calling the `calculateEstimate` function (from `/lib/estimates.js`) to calculate the purchase interval estimate. This action is performed and the result saved within the `ShoppingList `component's `checkAsPurchased `function, which fires when the user checks off an item as purchased.

A few notes:
- `calculateEstimate` requires 3 parameters: `lastEstimate` (last estimated purchase interval), `latestInterval` (days between the most recent and previous purchase) and `numberOfPurchases`

- We can provide the `lastEstimate` and `numberOfPurchases` from the item's current data, but need to calculate `latestInterval` from the item's `lastPurchaseDate` and the current time. We added the Luxon date library and converted dates to Luxon's DateTime object to handle this.

- As instructed by a prior issue's AC, when an item is first saved to the Firestore database, the `lastPurchaseDate` is set to null because there's no purchase history yet. Since it's impossible to calculate a `latestInterval` between the current date and a null value, we ensure there will always be a default value used as the `latestInterval` in this case. We use the item's current purchaseInterval as the default value, which is initially set by the user when they add the item (7, 14, or 30 days).

## Related Issue

Closes #10 : As an item, I want my estimated next purchase date to be computed at the time my purchase is recorded in the database so the app can learn how often I buy different items.

## Acceptance Criteria

- [ ] When a purchase is recorded, the estimated number of days until the next purchase date should be calculated and recorded in the database

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
| ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
| ✓ | :link: Update dependencies |
|    | :scroll: Docs              |


## Testing Steps / QA Criteria

1. Pull branch and npm install to add the Luxon package.
2. Take note of an item's purchaseInterval in the database.
3. Check off that item in the UI.
4. The `purchaseInterval` for that item should update in the database, according to the formula in the `calculateEstimate` function. 
(Note: the first time an item is checked off as purchased, the `purchaseInterval` should not change because there's not enough purchase history to calculate a meaningful estimate. When an item has been purchased at least once before, the `purchaseInterval` should usually change. You may need to manipulate the `lastPurchaseDate` or `numberOfPurchases` in Firestore in order to observe how the `purchaseInterval` updates in different scenarios.)


