### PR TITLE
Sort list items

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -87,3 +87,13 @@ BEM conventions we are using:
   margin: 0;
   list-style: none;
 }
+
+.visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -1,4 +1,6 @@
 import { useState, useRef } from 'react';
+
+import firebase from 'firebase/app';
 import { db } from '../../lib/firebase.js';
 
 const AddItemForm = ({ listId }) => {
@@ -82,6 +84,7 @@ const AddItemForm = ({ listId }) => {
       purchaseInterval: Number(formValues.purchaseInterval),
       lastPurchaseDate: null,
       numberOfPurchases: 0,
+      createdAt: firebase.firestore.FieldValue.serverTimestamp(),
     };
 
     try {

--- a/src/components/ShoppingList/ShoppingList.js
+++ b/src/components/ShoppingList/ShoppingList.js
@@ -86,6 +86,7 @@ function ShoppingList({ listId }) {
     const currentDate = DateTime.fromSeconds(Math.floor(Date.now() / 1000));
 
     if (item.lastPurchaseDate?.seconds) {
+      // if an item has been purchased before, compare the time elapsed since lastPurchaseDate to the purchaseInterval
       return (
         currentDate
           .diff(DateTime.fromSeconds(item.lastPurchaseDate.seconds), ['days'])
@@ -93,6 +94,7 @@ function ShoppingList({ listId }) {
         2 * item.purchaseInterval
       );
     } else if (item.createdAt?.seconds) {
+      // if an item has never been purchased, do the same calculating using createdAt date instead of lastPurchaseDate
       return (
         currentDate
           .diff(DateTime.fromSeconds(item.createdAt.seconds), ['days'])
@@ -131,6 +133,8 @@ function ShoppingList({ listId }) {
     if (item.daysToPurchase > 30) return 'not-soon';
   };
 
+  // format the data from firestore into a sorted, filtered array of items
+  // add new properties: item.status and item.daysToPurchase
   const itemsToDisplay = listItems?.docs
     .filter((doc) => new RegExp(filter, 'i').test(doc.data().itemName))
     .map((doc) => {

--- a/src/components/ShoppingList/ShoppingList.js
+++ b/src/components/ShoppingList/ShoppingList.js
@@ -82,14 +82,41 @@ function ShoppingList({ listId }) {
     return daysRemaining.as('days');
   };
 
+  const isItemInactive = (item) => {
+    const currentDate = DateTime.fromSeconds(Math.floor(Date.now() / 1000));
+
+    if (item.lastPurchaseDate?.seconds) {
+      return (
+        currentDate
+          .diff(DateTime.fromSeconds(item.lastPurchaseDate.seconds), ['days'])
+          .as('days') >=
+        2 * item.purchaseInterval
+      );
+    } else if (item.createdAt?.seconds) {
+      return (
+        currentDate
+          .diff(DateTime.fromSeconds(item.createdAt.seconds), ['days'])
+          .as('days') >=
+        2 * item.purchaseInterval
+      );
+    } else return null;
+  };
+
   const sortListItems = (docOne, docTwo) => {
     const itemOne = docOne.data();
     const itemTwo = docTwo.data();
     const daysToPurchaseItemOne = getDaysToPurchase(itemOne);
     const daysToPurchaseItemTwo = getDaysToPurchase(itemTwo);
+    const itemOneInactive = isItemInactive(itemOne);
+    const itemTwoInactive = isItemInactive(itemTwo);
 
-    if (daysToPurchaseItemOne < daysToPurchaseItemTwo) return -1;
-    if (daysToPurchaseItemOne > daysToPurchaseItemTwo) return 1;
+    if (itemOneInactive === itemTwoInactive) {
+      if (daysToPurchaseItemOne < daysToPurchaseItemTwo) return -1;
+      if (daysToPurchaseItemOne > daysToPurchaseItemTwo) return 1;
+    } else {
+      if (itemTwoInactive) return -1;
+      if (itemOneInactive) return 1;
+    }
   };
 
   const createListElement = () => {
@@ -140,7 +167,6 @@ function ShoppingList({ listId }) {
                   itemId={doc.id}
                   item={doc.data()}
                   checkAsPurchased={checkAsPurchased}
-                  daysToPurchase={getDaysToPurchase(doc.data())}
                 />
               ))}
           </ul>

--- a/src/components/ShoppingList/ShoppingList.js
+++ b/src/components/ShoppingList/ShoppingList.js
@@ -110,6 +110,12 @@ function ShoppingList({ listId }) {
     ) {
       if (itemA.daysToPurchase < itemB.daysToPurchase) return -1;
       if (itemA.daysToPurchase > itemB.daysToPurchase) return 1;
+
+      // if we've made it this far, days to purchase is the same for both items so alphabetize
+      return itemA.itemName.localeCompare(itemB.itemName, 'en', {
+        sensitivity: 'base',
+        ignorePunctuation: true,
+      });
     } else {
       // if one item is inactive and the other is not, bump down the inactive item
       if (itemA.status === 'inactive') return 1;

--- a/src/components/ShoppingList/ShoppingList.js
+++ b/src/components/ShoppingList/ShoppingList.js
@@ -22,6 +22,7 @@ function ShoppingList({ listId }) {
   // format the data from firestore into a sorted, filtered array of items
   // add new properties: item.status and item.daysToPurchase
   const itemsToDisplay = listItems?.docs
+    // filter first to minimize mapping and sorting work
     .filter((doc) => new RegExp(filter, 'i').test(doc.data().itemName))
     .map((doc) => {
       const item = doc.data();
@@ -32,6 +33,15 @@ function ShoppingList({ listId }) {
     })
     .sort(sortListItems);
 
+  /**
+   * Calculate the number of days until the estimated next purchase date, based on the
+   * purchaseInterval and lastPurchaseDate (or createdAt date for new items not yet purchased)
+   *
+   * @param {Object} item A list item with properties lastPurchaseDate, purchaseInterval, and createdAt
+   * (retrieved from Firestore item field data)
+   *
+   * @return {Number} Number of days remaining until the estimated next purchase date
+   */
   function getDaysToPurchase(item) {
     let nextPurchaseDate;
     if (item.lastPurchaseDate?.seconds) {
@@ -51,6 +61,20 @@ function ShoppingList({ listId }) {
     return Math.round(daysRemaining.as('days'));
   }
 
+  /**
+   * Returns a string label indicating the status of an item, based on how soon the next purchase date is estimated to be
+   * (strings chosen to be useful as CSS class modifiers)
+   * - 'soon' indicates less than 7 days are left until the next estimated purchase date
+   * - 'kind-of-soon' indicates there are 7-30 days left until the next estimated purchase date
+   * - 'not-soon' indicates there are more than 30 days left until the next estimated purchase date
+   * - 'inactive' indicates more than 2x the estimated purchaseInterval has elapsed since the last purchase or date created
+   * @see isItemInactive
+   *
+   * @param {Object} item A list item with properties lastPurchaseDate, purchaseInterval, createdAt and daysToPurchase
+   * (retrieved from Firestore item field data, with 'daysToPurchase' property added)
+   *
+   * @return {String} Either 'soon', 'kind-of-soon', 'not-soon' or 'inactive'
+   */
   function getItemStatus(item) {
     if (isItemInactive(item)) return 'inactive';
     if (item.daysToPurchase < 7) return 'soon';
@@ -59,6 +83,15 @@ function ShoppingList({ listId }) {
     if (item.daysToPurchase > 30) return 'not-soon';
   }
 
+  /**
+   * Checks whether an item is inactive. An item is considered inactive once more than 2x the purchaseInterval
+   * has elapsed since the last date the item was purchased (or the date the item was created if never purchased)
+   *
+   * @param {Object} item A list item with properties lastPurchaseDate, purchaseInterval, and createdAt
+   * (retrieved from Firestore item field data)
+   *
+   * @return {Boolean} Whether item is inactive (true) or not (false)
+   */
   function isItemInactive(item) {
     const estimateDate =
       item.lastPurchaseDate?.seconds || item.createdAt?.seconds;
@@ -73,8 +106,22 @@ function ShoppingList({ listId }) {
     }
   }
 
+  /**
+   * To be used with Array.prototype.sort(), this function compares items according to the following rules:
+   * - items that are inactive always come later than items that are active
+   * - all items are sorted by estimated number of days until next purchase date, with those expected to be
+   *   bought sooner appearing higher up on the list
+   * - items with the same estimated number of days until next purchase date are sorted alphabetically
+   *
+   * @param {Object} itemA A list item with properties status, daysToPurchase, and itemName
+   * (retrieved from Firestore item field data, with 'status' and 'daysToPurchase' properties added)
+   * @param {Object} itemB A second list item to compare against
+   *
+   * @return {Number} a positive number indicating the itemA should appear later than itemB OR
+   * negative number indicating itemA should appear after itemB OR 0 indicating both are considered equal
+   */
   function sortListItems(itemA, itemB) {
-    // if items being compared are both inactive, or neither is inactive, sort by days until next purchase
+    // if both items are inactive, or neither is inactive, sort by days until next purchase
     if (
       (itemA.status === 'inactive' && itemB.status === 'inactive') ||
       (itemA.status !== 'inactive' && itemB.status !== 'inactive')

--- a/src/components/ShoppingListItem/ShoppingListItem.css
+++ b/src/components/ShoppingListItem/ShoppingListItem.css
@@ -1,0 +1,15 @@
+.item__label_soon {
+  background: #e5f5e1;
+}
+
+.item__label_kind-of-soon {
+  background: #fff2da;
+}
+
+.item__label_not-soon {
+  background: #fee0d4;
+}
+
+.item__label_inactive {
+  background: #eee;
+}

--- a/src/components/ShoppingListItem/ShoppingListItem.js
+++ b/src/components/ShoppingListItem/ShoppingListItem.js
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react';
 
 import isUnder24hSincePurchased from '../../utils/isUnder24hSincePurchased.js';
 
+import './ShoppingListItem.css';
+
 const ShoppingListItem = ({ item, checkAsPurchased }) => {
   const [recentlyPurchased, setRecentlyPurchased] = useState(false);
 
@@ -22,14 +24,13 @@ const ShoppingListItem = ({ item, checkAsPurchased }) => {
         type="checkbox"
         disabled={recentlyPurchased}
         checked={recentlyPurchased}
-        className={`checkbox shopping-list__checkbox 
-        ${recentlyPurchased} ? 'checkbox_recently-purchased' : '' 
-        checkbox_${item.status}
-        `}
+        className={`checkbox item__checkbox ${
+          recentlyPurchased ? 'checkbox_recently-purchased' : ''
+        } item__checkbox_${item.status}`}
         onChange={() => checkAsPurchased(item)}
       />
       <label
-        className="label label_check-radio shopping-list__label"
+        className={`label label_check-radio item__label item__label_${item.status}`}
         htmlFor={`item-${item.id}`}
       >
         {item.itemName}

--- a/src/components/ShoppingListItem/ShoppingListItem.js
+++ b/src/components/ShoppingListItem/ShoppingListItem.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 
 import isUnder24hSincePurchased from '../../utils/isUnder24hSincePurchased.js';
 
-const ShoppingListItem = ({ listId, itemId, item, checkAsPurchased }) => {
+const ShoppingListItem = ({ item, checkAsPurchased }) => {
   const [recentlyPurchased, setRecentlyPurchased] = useState(false);
 
   // update whether item is recently purchased
@@ -17,19 +17,28 @@ const ShoppingListItem = ({ listId, itemId, item, checkAsPurchased }) => {
   return (
     <li className="shopping-list__item item">
       <input
-        id={`item-${itemId}`}
-        value={itemId}
+        id={`item-${item.id}`}
+        value={item.id}
         type="checkbox"
         disabled={recentlyPurchased}
         checked={recentlyPurchased}
-        className={`checkbox shopping-list__checkbox ${recentlyPurchased} ? 'checkbox_recently-purchased' : '' `}
-        onChange={() => checkAsPurchased(itemId, item)}
+        className={`checkbox shopping-list__checkbox 
+        ${recentlyPurchased} ? 'checkbox_recently-purchased' : '' 
+        checkbox_${item.status}
+        `}
+        onChange={() => checkAsPurchased(item)}
       />
       <label
         className="label label_check-radio shopping-list__label"
-        htmlFor={`item-${itemId}`}
+        htmlFor={`item-${item.id}`}
       >
         {item.itemName}
+        <span className="visually-hidden">
+          {item.status === 'soon' && ' Need to buy soon'}
+          {item.status === 'kind-of-soon' && ' Need to buy kind of soon'}
+          {item.status === 'not-soon' && " Don't need to buy soon"}
+          {item.status === 'inactive' && ' Inactive'}
+        </span>
       </label>
     </li>
   );

--- a/src/components/ShoppingListItem/ShoppingListItem.js
+++ b/src/components/ShoppingListItem/ShoppingListItem.js
@@ -35,6 +35,7 @@ const ShoppingListItem = ({ item, checkAsPurchased }) => {
       >
         {item.itemName}
         <span className="visually-hidden">
+          {/* text for screen readers only, based on item.status set in ShoppingList with getItemStatus function */}
           {item.status === 'soon' && ' Need to buy soon'}
           {item.status === 'kind-of-soon' && ' Need to buy kind of soon'}
           {item.status === 'not-soon' && " Don't need to buy soon"}


### PR DESCRIPTION
## Description
This PR adds functionality to sort Shopping List items in order of how soon they are expected to be purchased, with items that seem to be inactive sorted to the bottom. 

Note: We decided that it seemed counterintuitive to have new items immediately be considered 'inactive' and sorted to the bottom of the list, but since new items have never been purchased, there is no `lastPurchaseDate` to use to calculate when the next purchase is expected. To handle this, we made a minor change to the data structure adding a `createdAt` timestamp, and for new items we calculate their days until next purchase and inactivity based on that date instead.

## ShoppingList.js

### `getDaysToPurchase`

The `getDaysToPurchase()` function estimates how many days remain until the application expects the user to purchase an item again. If the item has been purchased before, next purchase date is `[purchaseInterval]` days from the last purchase date. If there is no purchase history, the function estimates that the item will be bought `[purchaseInterval]` days from when it was first added to the list.

### `sortListItems` 

The `sortListItems()` function is a [compare function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) which we pass into a `.sort()` call on our array of items. The function sorts items based first on their "status", a new property for each item which is based on the days to purchase (calculated by `getDaysToPurchase()`). After the days to purchase, the function sorts the items alphabetically using [.localeCompare.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) 

### `isItemInactive` 

The `isItemInactive()` function determines whether an item is "inactive" based on the parameters laid out in the AC (there’s only 1 purchase in the database or the purchase is really out of date [the time that has elapsed since the last purchase is 2x what was estimated]). 


## ShoppingListItem.js

We added a `<span>`, which is visually hidden, for content that will be read by screen readers. The text that is read is based on the item status. Finally, set the class of the `<label>` to be conditionally based on `item.status`, and styled the relevant classes with different colors to make the items visually distinct, based on their "status". 

## Related Issue

Closes #12. 

## Acceptance Criteria

- [x] Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive
- [x] Items should be sorted by the estimated number of days until next purchase
- [x] Items with the same number of estimated days until next purchase should be sorted alphabetically
- [x] Items in the different states should be described distinctly when read by a screen reader

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
| ✓ | :sparkles: New feature     |
| ✓ | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

![image](https://user-images.githubusercontent.com/67769490/129988928-e4d3de6a-6253-47e7-b241-57d64051a609.png)

### After

![image](https://user-images.githubusercontent.com/67769490/129988991-8cdd035f-4839-474a-8f06-d42f1b430445.png)


## Testing Steps / QA Criteria

1. Pull down the branch, and run npm install if you haven't yet installed the dependencies.
2. Run npm start to start the local server.
3. Make sure you are using a list with a variety of items with different purchase histories and calculated purchase intervals to best observe sorting. You can join the list with token 'watts burly enrico' to meet this requirement, and/or manipulate data in the firestore console.
4. Compare the items in the firestore database, and check whether they are sorting according to the following rules:
   - Items are sorted by the estimated number of days until next purchase (the difference between the current date and the `lastPurchaseDate`, or `createdAt` for new items, plus `[purchaseInterval]` days, rounded to the nearest day)
   - Items expected to be purchased sooner appear higher up
   - If more than 2 x `[purchaseInterval]` days have passed since an item's `lastPurchaseDate` (or `createdAt` date for new items), it is inactive and should be sorted to the bottom of the list
   - Items with the same estimated number of days until purchase are sorted alphabetically
5. Make sure the items have an appropriately coloured label and hidden screen reader text indicating these different possible item states: 
   - Need to buy soon (fewer than 7 days)
   - Need to buy kind of soon (between 7 & 30 days)
   - Need to buy not soon (more than 30 days)
   - Inactive (the time that has elapsed since the last purchase is 2x what was estimated)