### PR TITLE
Checkbox icon colour-coding

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,10 +18,16 @@ BEM conventions we are using:
 */
 
 :root {
-  --main-accent-color: #3fa448; /* sample accent color, a11y: passes AA for 18pt text */
+  --main-accent-color: #408a10; /* sample accent color, a11y: passes AA for 18pt text */
   --highlight-color: #ffc62e; /* sample highlight color, used for key nav focus outlines */
   --warning-color: #dd380a; /* a11y: passes AA at 16 pt for text or bg with white */
   --warning-color-focus: #a1381b; /* focus/hover alternative */
+
+  /* icons must have contrast of 3:1 according to WCAG */
+  --item-soon-color: #36700f;
+  --item-kinda-soon-color: #408a10;
+  --item-not-soon-color: #54a71d;
+  --item-inactive-color: #8e8d96;
 
   --light-gray: #f3f2f7;
   --medium-gray: #dddce6;

--- a/src/App.css
+++ b/src/App.css
@@ -28,8 +28,8 @@ CSS Organization reference: https://gist.github.com/awkale/ad46e2ade70e833fa178
   --warning-color-focus: #a1381b; /* focus/hover alternative */
 
   /* icons must have contrast of 3:1 according to WCAG */
-  --item-soon-color: #36700f;
-  --item-kinda-soon-color: #408a10;
+  --item-soon-color: #2e6907;
+  --item-kind-of-soon-color: #408a10;
   --item-not-soon-color: #54a71d;
   --item-inactive-color: #8e8d96;
 

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -162,14 +162,14 @@ const AddItemForm = ({ listId }) => {
         <input
           type="radio"
           className="radio"
-          id="kindaSoonOption"
+          id="kindOfSoonOption"
           name="purchaseInterval"
           value="14"
           onChange={handleChange}
           checked={formValues.purchaseInterval === '14'}
         />
         <label
-          htmlFor="kindaSoonOption"
+          htmlFor="kindOfSoonOption"
           className="add-item-form__label add-item-form__label_type_radio label label_type_check-radio"
         >
           Kind of Soon

--- a/src/components/ShoppingListItem/ShoppingListItem.css
+++ b/src/components/ShoppingListItem/ShoppingListItem.css
@@ -59,21 +59,15 @@
   color: var(--warning-color);
 }
 
-.checkbox-target {
-  display: block;
-  height: var(--icon-size-sm);
-  width: var(--icon-size-sm);
-  padding: 0.125rem;
-  margin: 0;
-  cursor: pointer;
-  border-radius: 3px; /* so a11y focus outline is not all pointy */
-}
-
 @media only screen and (min-width: 600px) {
   .checkbox-target {
     width: var(--icon-size-lg);
     height: var(--icon-size-lg);
   }
+}
+
+.checkbox-icon__mark {
+  transition: all var(--transition-timing);
 }
 
 .checkbox-icon__border {
@@ -96,4 +90,35 @@
 
 .checkbox:focus-visible + .checkbox-target {
   box-shadow: 0 0 0 3px var(--highlight-color); /* a11y outline for keyboard nav only */
+}
+
+.checkbox-target_status_soon {
+  color: var(--item-soon-color);
+}
+
+.checkbox-target_status_kind-of-soon {
+  color: var(--item-kinda-soon-color);
+}
+
+.checkbox-target_status_not-soon {
+  color: var(--item-not-soon-color);
+}
+
+.checkbox-target_status_inactive {
+  color: var(--item-inactive-color);
+}
+
+.checkbox-target {
+  color: var(--item-soon-color);
+  display: block;
+  height: var(--icon-size-sm);
+  width: var(--icon-size-sm);
+  padding: 0.125rem;
+  margin: 0;
+  cursor: pointer;
+  border-radius: 3px; /* so a11y focus outline is not all pointy */
+}
+
+.checkbox-target:hover .checkbox-icon__mark {
+  fill: rgba(255, 255, 255, 0.35);
 }

--- a/src/components/ShoppingListItem/ShoppingListItem.css
+++ b/src/components/ShoppingListItem/ShoppingListItem.css
@@ -1,3 +1,60 @@
+.checkbox-icon__mark {
+  transition: all var(--transition-timing);
+}
+
+.checkbox-icon__border {
+  fill: currentColor;
+}
+
+.checkbox-icon__bg {
+  fill: currentColor;
+}
+
+/* by default, checkbox icon unchecked */
+.checkbox-icon__mark {
+  fill: none;
+}
+
+/* if checkbox input is checked, change the SVG color in the label.checkbox-target beside it */
+.checkbox:checked + .checkbox-target .checkbox-icon__mark {
+  fill: #fff;
+}
+
+.checkbox:focus-visible + .checkbox-target {
+  box-shadow: 0 0 0 3px var(--highlight-color); /* a11y outline for keyboard nav only */
+}
+
+.checkbox-target {
+  color: var(--item-soon-color);
+  display: block;
+  height: var(--icon-size-sm);
+  width: var(--icon-size-sm);
+  padding: 0.125rem;
+  margin: 0;
+  cursor: pointer;
+  border-radius: 3px; /* so a11y focus outline is not all pointy */
+}
+
+.checkbox-target:hover .checkbox-icon__mark {
+  fill: rgba(255, 255, 255, 0.35);
+}
+
+.checkbox-target_status_soon {
+  color: var(--item-soon-color);
+}
+
+.checkbox-target_status_kind-of-soon {
+  color: var(--item-kind-of-soon-color);
+}
+
+.checkbox-target_status_not-soon {
+  color: var(--item-not-soon-color);
+}
+
+.checkbox-target_status_inactive {
+  color: var(--item-inactive-color);
+}
+
 .item {
   display: flex;
   align-items: center;
@@ -37,68 +94,4 @@
 .item__delete-button:hover,
 .item__delete-button:focus {
   color: var(--warning-color);
-}
-
-@media only screen and (min-width: 600px) {
-  .checkbox-target {
-    width: var(--icon-size-lg);
-    height: var(--icon-size-lg);
-  }
-}
-
-.checkbox-icon__mark {
-  transition: all var(--transition-timing);
-}
-
-.checkbox-icon__border {
-  fill: currentColor;
-}
-
-.checkbox-icon__bg {
-  fill: currentColor;
-}
-
-/* by default, checkbox icon unchecked */
-.checkbox-icon__mark {
-  fill: none;
-}
-
-/* if checkbox input is checked, change the SVG color in the label.checkbox-target beside it */
-.checkbox:checked + .checkbox-target .checkbox-icon__mark {
-  fill: #fff;
-}
-
-.checkbox:focus-visible + .checkbox-target {
-  box-shadow: 0 0 0 3px var(--highlight-color); /* a11y outline for keyboard nav only */
-}
-
-.checkbox-target_status_soon {
-  color: var(--item-soon-color);
-}
-
-.checkbox-target_status_kind-of-soon {
-  color: var(--item-kinda-soon-color);
-}
-
-.checkbox-target_status_not-soon {
-  color: var(--item-not-soon-color);
-}
-
-.checkbox-target_status_inactive {
-  color: var(--item-inactive-color);
-}
-
-.checkbox-target {
-  color: var(--item-soon-color);
-  display: block;
-  height: var(--icon-size-sm);
-  width: var(--icon-size-sm);
-  padding: 0.125rem;
-  margin: 0;
-  cursor: pointer;
-  border-radius: 3px; /* so a11y focus outline is not all pointy */
-}
-
-.checkbox-target:hover .checkbox-icon__mark {
-  fill: rgba(255, 255, 255, 0.35);
 }

--- a/src/components/ShoppingListItem/ShoppingListItem.css
+++ b/src/components/ShoppingListItem/ShoppingListItem.css
@@ -1,23 +1,3 @@
-/*
-
-.item__label_soon {
-  background: #e5f5e1;
-}
-
-.item__label_kind-of-soon {
-  background: #fff2da;
-}
-
-.item__label_not-soon {
-  background: #fee0d4;
-}
-
-.item__label_inactive {
-  background: #eee;
-}
-
-*/
-
 .item {
   display: flex;
   align-items: center;

--- a/src/components/ShoppingListItem/ShoppingListItem.js
+++ b/src/components/ShoppingListItem/ShoppingListItem.js
@@ -27,7 +27,7 @@ const ShoppingListItem = ({ item, checkAsPurchased, handleModalOpen }) => {
         type="checkbox"
         disabled={recentlyPurchased}
         checked={recentlyPurchased}
-        className="checkbox visually-hidden"
+        className="checkbox "
         onChange={() => checkAsPurchased(item)}
       />
       <label

--- a/src/components/ShoppingListItem/ShoppingListItem.js
+++ b/src/components/ShoppingListItem/ShoppingListItem.js
@@ -27,7 +27,7 @@ const ShoppingListItem = ({ item, checkAsPurchased, handleModalOpen }) => {
         type="checkbox"
         disabled={recentlyPurchased}
         checked={recentlyPurchased}
-        className="checkbox "
+        className="checkbox visually-hidden"
         onChange={() => checkAsPurchased(item)}
       />
       <label


### PR DESCRIPTION
## Description

This PR adds CSS for colour-coding the checkbox icons according to an item's status. Colours are stored in CSS variables so as to be easy for us to adjust when finalizing design. Also adds a checkbox hover state.

## Related Issue

Closes #60

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before


<img width="700" src="https://user-images.githubusercontent.com/67769490/131183398-281d1f86-6b8f-4a9e-a474-b636891b87ab.png" alt="before screen shot: checkboxes without colour code" />

### After

<img width="700" src="https://user-images.githubusercontent.com/67769490/131182467-84e8dc6e-541b-47b8-a9ac-16064933203d.gif" alt="after screen cast: checkboxes with colour code" />

## Testing Steps / QA Criteria

1. Make a local copy of the branch and run npm start.
2. Make sure you are using a list with items in all four status categories ('soon', 'kind of soon', 'not soon' and 'inactive').
3. Ensure that the checkbox icon used for inactive items is gray, and the checkbox icons used for other items are the deepest/fullest colour for items to be bought soon, a lighter colour for those due kind of soon, and the palest colour for those due not soon. 
4. Check for a hover affect when hovering over an unchecked checkbox, as in provded screen cast.

