### PR TITLE
Basic modal style

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,6 +31,7 @@ BEM conventions we are using:
 
   --border-width: 2px; /* consistent border width for UI elements, dividers, etc. */
   --ui-border-radius: 7px; /* for buttons, text fields */
+  --container-border-radius: 16px; /* for modals, panels, etc. */
 
   --icon-size-sm: 28px;
   --icon-size-lg: 32px;
@@ -38,6 +39,8 @@ BEM conventions we are using:
   /* text fields styles */
   --input-bg-color: var(--medium-gray);
   --input-border-color: var(--medium-gray);
+
+  --overlay-background: rgba(0, 0, 0, 0.3);
 
   --transition-timing: 0.25s ease-in-out; /* consistent transitions on UI elements */
 }
@@ -51,12 +54,6 @@ BEM conventions we are using:
 @media only screen and (min-width: 600px) {
   .global {
     font-size: 1.25rem;
-  }
-}
-
-@media only screen and (min-width: 1200px) {
-  .global {
-    font-size: 1.375em;
   }
 }
 

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -1,12 +1,5 @@
-.dialog-open {
-  display: block;
-}
-
-.dialog-close {
+.dialog {
   display: none;
-}
-
-.dialog-backdrop {
   position: fixed;
   overflow-y: auto;
   top: 0;
@@ -16,7 +9,11 @@
   background: rgba(0, 0, 0, 0.3);
 }
 
-[role='alertdialog'] {
+.dialog_open {
+  display: block;
+}
+
+.dialog__modal {
   position: absolute;
   top: 2rem;
   left: 35vw;

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -1,24 +1,61 @@
 .dialog {
-  display: none;
   position: fixed;
-  overflow-y: auto;
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
-  background: rgba(0, 0, 0, 0.3);
+  overflow-y: auto;
+  display: none;
+  justify-content: center;
+  align-items: center;
+  background: var(--overlay-background);
 }
 
 .dialog_open {
-  display: block;
+  display: flex;
 }
 
 .dialog__modal {
-  position: absolute;
-  top: 2rem;
-  left: 35vw;
-
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  max-width: 600px;
+  padding: 2rem 1rem;
+  margin: 1rem;
   box-sizing: border-box;
-  padding: 15px;
-  background-color: #fff;
+  background: #fff;
+  border-radius: var(--container-border-radius);
+}
+
+.dialog__heading {
+  flex-basis: 100%;
+  padding: 0;
+  margin: 0 1rem 1rem 1rem; /* side margins to allow for button gap only when room */
+  font-size: 1.25rem;
+  font-weight: 400;
+  text-align: center;
+}
+
+.dialog__item-name {
+  font-weight: 700;
+}
+
+.dialog__button {
+  flex-grow: 1;
+  margin: 1rem 1rem 0 1rem; /* side margins to allow for button gap only when room */
+}
+
+@media only screen and (min-width: 600px) {
+  .dialog__modal {
+    margin: 20vh 4rem 4rem 4rem;
+  }
+
+  .dialog {
+    align-items: flex-start;
+  }
+
+  .dialog__heading {
+    font-size: 1.5rem;
+  }
 }

--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -4,15 +4,22 @@
   right: 0;
   bottom: 0;
   left: 0;
+  display: flex;
   overflow-y: auto;
-  display: none;
   justify-content: center;
   align-items: center;
   background: var(--overlay-background);
+  /* smooth transition in */
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--transition-timing),
+    visibility var(--transition-timing);
 }
 
 .dialog_open {
-  display: flex;
+  opacity: 1;
+  visibility: visible;
+  transition: opacity var(--transition-timing);
 }
 
 .dialog__modal {

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -46,10 +46,11 @@ const Modal = ({ showModal, handleModalClose, deleteItem, item }) => {
         aria-labelledby="dialog-label"
       >
         <h3 className="dialog__heading" id="dialog-label">
-          {`Are you sure you want to delete ${item.itemName}?`}
+          Are you sure you want to delete{' '}
+          <strong className="dialog__item-name">{item.itemName}</strong>?
         </h3>
         <button
-          className="dialog__cancel button"
+          className="dialog__button button"
           type="button"
           onClick={handleModalClose}
           ref={cancelRef}
@@ -57,7 +58,7 @@ const Modal = ({ showModal, handleModalClose, deleteItem, item }) => {
           No, Cancel
         </button>
         <button
-          className="dialog__delete button button_type_delete"
+          className="dialog__button button button_type_delete"
           type="button"
           onClick={deleteItem}
           aria-controls={`item-${item.id}`} // destructive delete controls shopping list item id

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import './Modal.css';
 
 const Modal = ({ showModal, handleModalClose, deleteItem, item }) => {
-  const toggleModalClassName = showModal ? 'dialog-open' : 'dialog-close';
+  const toggleModalClassName = showModal ? 'dialog_open' : '';
 
   const cancelRef = useRef();
   const deleteRef = useRef();
@@ -38,13 +38,18 @@ const Modal = ({ showModal, handleModalClose, deleteItem, item }) => {
   }, [handleModalClose, showModal]);
 
   return (
-    <div className={`dialog-backdrop ${toggleModalClassName}`}>
-      <div role="alertdialog" aria-modal="true" aria-labelledby="dialog_label">
-        <h3 id="dialog_label">
+    <div className={`dialog ${toggleModalClassName}`}>
+      <div
+        className="dialog__modal"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="dialog-label"
+      >
+        <h3 className="dialog__heading" id="dialog-label">
           {`Are you sure you want to delete ${item.itemName}?`}
         </h3>
         <button
-          className="button"
+          className="dialog__cancel button"
           type="button"
           onClick={handleModalClose}
           ref={cancelRef}
@@ -52,7 +57,7 @@ const Modal = ({ showModal, handleModalClose, deleteItem, item }) => {
           No, Cancel
         </button>
         <button
-          className="button button_type_delete"
+          className="dialog__delete button button_type_delete"
           type="button"
           onClick={deleteItem}
           aria-controls={`item-${item.id}`} // destructive delete controls shopping list item id

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -29,12 +29,23 @@ const Modal = ({ showModal, handleModalClose, deleteItem, item }) => {
         }
       }
     };
+
+    const closeOnClickOutside = (e) => {
+      if (e.target.classList.contains('dialog')) {
+        handleModalClose();
+      }
+    };
+
     if (showModal) {
       // when modal opens, add eventListeners and put initial focus on "No, Cancel"
       document.addEventListener('keydown', handleKeyEvents);
+      document.addEventListener('click', closeOnClickOutside);
       cancelRef.current.focus();
     }
-    return () => document.removeEventListener('keydown', handleKeyEvents);
+    return () => {
+      document.removeEventListener('keydown', handleKeyEvents);
+      document.removeEventListener('click', closeOnClickOutside);
+    };
   }, [handleModalClose, showModal]);
 
   return (


### PR DESCRIPTION
## Description

This PR uses our global CSS classes/variables and adds basic styles to the modal to match the wireframe. It also add an additional event listener to close the modal when the user clicks outside it.

## Related Issue

Closes #59 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
| ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

![image](https://user-images.githubusercontent.com/67769490/131177949-eb46fff9-f660-4b6f-98b2-278ffeff149a.png)

### After

![image](https://user-images.githubusercontent.com/67769490/131178230-b5bd129a-0854-453b-a924-9d29ff651118.png)
![modal](https://user-images.githubusercontent.com/67769490/131185850-461ccc8f-a55e-463a-9ae8-ea25848eca5d.gif)


## Testing Steps / QA Criteria

1. Pull down the branch and install dependencies if you haven't already.
2. Run npm start to start the local server.
3. Open the modal by clicking the delete button for an item. Check whether it matches the screenshot. 
4. Close and open the modal, and check that it fades in and out smoothly.
5. Try closing the modal by clicking outside of the box on the backdrop overlay.

