### PR TITLE
Hide share token

### DIFF
--- a/src/components/ListHeader/ListHeader.css
+++ b/src/components/ListHeader/ListHeader.css
@@ -32,16 +32,25 @@
   margin: 1.25rem 0 0.25rem 0;
 }
 
-@media only screen and (min-width: 800px) {
+@media only screen and (min-width: 900px) {
   .list-header {
     display: grid;
     grid-template:
       'main share-toggle'
       'main share-token';
-    grid-template-columns: max-content min-content;
+    grid-template-columns: 1fr min-content;
+  }
+
+  .list-header__main {
+    grid-row: 1 / 3;
+  }
+
+  .list-header__share-toggle-button {
+    position: static;
+    grid-area: share-toggle;
   }
 
   .list-header__share-token {
-    margin: 0;
+    grid-area: share-token;
   }
 }

--- a/src/components/ListHeader/ListHeader.css
+++ b/src/components/ListHeader/ListHeader.css
@@ -23,7 +23,7 @@
 
 .list-header__share-toggle-button {
   position: absolute;
-  top: 0;
+  top: 0.5rem;
   right: 0;
 }
 
@@ -51,6 +51,11 @@
   }
 
   .list-header__share-token {
+    grid-area: share-token;
+    margin: 0 0.375rem 0.25rem 1rem;
+  }
+
+  .list-header__share-token-hint {
     grid-area: share-token;
   }
 }

--- a/src/components/ShareToken/ShareToken.css
+++ b/src/components/ShareToken/ShareToken.css
@@ -2,7 +2,7 @@
 
 .share-toggle-button {
   display: grid;
-  grid-template-columns: auto auto;
+  grid-template-columns: min-content max-content;
 }
 
 .share-toggle-button,
@@ -52,7 +52,7 @@
   transition: opacity var(--transition-timing);
 }
 
-.share-token_mobile_show {
+.share-token_show {
   display: block;
 }
 
@@ -90,6 +90,7 @@
   .share-toggle-button {
     display: grid;
     padding: 0.375rem;
+    width: 13.5rem;
   }
 
   .share-toggle-button__icon {
@@ -117,14 +118,14 @@
     transition: 0.1s opacity var(--transition-timing);
   }
 
-  .share-token,
-  .share-token_mobile_show {
+  .share-token {
     display: block;
     padding: 0;
     opacity: 0;
   }
 
-  .share-token_desktop_show {
+  .share-token_show {
+    display: block;
     opacity: 1;
     transition: 0.1s opacity var(--transition-timing);
   }

--- a/src/components/ShareToken/ShareToken.css
+++ b/src/components/ShareToken/ShareToken.css
@@ -2,11 +2,11 @@
   display: none;
   padding: 0 0 1rem 0;
   font-size: 1rem;
+  text-align: center;
   background: var(--light-gray);
 }
 
-.share-token_mobile_show,
-.share-token_desktop_show {
+.share-token_mobile_show {
   display: block;
 }
 
@@ -74,10 +74,6 @@
   display: none;
 }
 
-.share-token {
-  text-align: center;
-}
-
 .share-token__token {
   padding-left: 2rem;
   font-size: 1.125rem;
@@ -85,61 +81,11 @@
   background-color: var(--main-accent-color-light) !important;
 }
 
-.copy-icon {
-  width: var(--icon-size-sm);
-  height: var(--icon-size-sm);
-  fill: currentColor;
-}
-
-.copied-icon {
-  width: var(--icon-size-lg);
-  height: var(--icon-size-lg);
-}
-.copied-icon .icon__bg,
-.copied-icon .icon__border {
-  fill: transparent;
-}
-
-.copied-icon .icon__mark {
-  fill: currentColor;
-}
-
-.share-token__copy-button {
-  transition: none;
-}
-
-.share-token__copy-button:after {
-  content: '';
-  opacity: 0;
-  transition: opacity var(--transition-timing);
-}
-
-.share-token__copy-button_copied,
-.share-token__copy-button_copied:hover,
-.share-token__copy-button_copied:focus {
-  color: var(--main-accent-color);
-}
-
-/* Show a tooltip when copy succeeds */
-.share-token__copy-button_copied:focus:after,
-.share-token__copy-button_copied:hover:after {
-  position: absolute;
-  bottom: -1.5rem;
-  color: var(--main-accent-color);
-  content: attr(aria-label); /* Use the "Copied!" aria-label as tooltip text */
-  opacity: 1;
-  transition: opacity var(--transition-timing);
-}
-
 @media only screen and (min-width: 800px) {
   .share-token {
     padding: 0;
     margin: 0.5rem 0 0 0;
     background: none;
-  }
-
-  .share-token_mobile_show {
-    display: none;
   }
 
   .share-token__token {
@@ -155,6 +101,7 @@
   .share-toggle-button__strong {
     display: block;
   }
+
   .share-toggle-button__hint {
     /* undo visually hidden for larger screens */
     position: static;
@@ -162,6 +109,16 @@
     height: auto;
     overflow: visible;
     white-space: normal;
+  }
+
+  .share-token,
+  .share-token_mobile_show {
+    display: block;
+    opacity: 0;
+  }
+
+  .share-token:focus {
+    opacity: 1;
   }
 }
 

--- a/src/components/ShareToken/ShareToken.css
+++ b/src/components/ShareToken/ShareToken.css
@@ -1,20 +1,8 @@
-.share-token {
-  display: none;
-  padding: 0 0 1rem 0;
-  font-size: 1rem;
-  text-align: center;
-  background: var(--light-gray);
-}
-
-.share-token_mobile_show {
-  display: block;
-}
+/* the share button */
 
 .share-toggle-button {
   display: grid;
   grid-template-columns: auto auto;
-  justify-items: center;
-  margin: 0.5rem 0 0 auto;
 }
 
 .share-toggle-button,
@@ -54,12 +42,27 @@
   white-space: nowrap;
 }
 
-.share-toggle-button__hint {
-  grid-column: 1 / 3;
+/* the token reveal area */
+
+.share-token {
+  display: none;
+  padding: 0 0 1rem 0;
+  font-size: 1rem;
+  text-align: center;
+  transition: opacity var(--transition-timing);
+}
+
+.share-token_mobile_show {
+  display: block;
+}
+
+/* the 'Reveal your token' helper text */
+.share-token-hint {
+  justify-self: end;
   max-width: 10rem;
-  margin: 0.5rem 0 0 0;
-  font-weight: 400;
+  margin: 0 1.75rem 0 0;
   font-size: 0.875rem;
+  font-weight: 400;
   color: var(--charcoal);
   text-align: center;
   /* make visually hidden on smaller screens */
@@ -70,39 +73,37 @@
   white-space: nowrap;
 }
 
-.share-toggle-button_desktop_expanded .share-toggle-button__hint {
-  display: none;
-}
-
 .share-token__token {
-  padding-left: 2rem;
   font-size: 1.125rem;
   text-align: center;
-  background-color: var(--main-accent-color-light) !important;
 }
 
-@media only screen and (min-width: 800px) {
-  .share-token {
-    padding: 0;
-    margin: 0.5rem 0 0 0;
-    background: none;
-  }
-
-  .share-token__token {
-    background: var(--light-gray);
-  }
+/* the 'Copied to clipboard' helper text */
+.share-token__copied {
+  display: block;
+  color: var(--main-accent-color);
+  font-weight: 600;
+  padding-top: 0.25rem;
 }
 
 @media only screen and (min-width: 900px) {
+  .share-toggle-button {
+    display: grid;
+    padding: 0.375rem;
+  }
+
   .share-toggle-button__icon {
     margin: 0 0.875rem -0.1875rem auto;
   }
 
   .share-toggle-button__strong {
     display: block;
+    font-size: 1.5rem;
   }
 
-  .share-toggle-button__hint {
+  .share-token-hint {
+    opacity: 0;
+    transition: opacity var(--transition-timing);
     /* undo visually hidden for larger screens */
     position: static;
     width: auto;
@@ -111,19 +112,20 @@
     white-space: normal;
   }
 
+  .share-token-hint_show {
+    opacity: 1;
+    transition: 0.1s opacity var(--transition-timing);
+  }
+
   .share-token,
   .share-token_mobile_show {
     display: block;
+    padding: 0;
     opacity: 0;
   }
 
-  .share-token:focus {
+  .share-token_desktop_show {
     opacity: 1;
-  }
-}
-
-@media only screen and (min-width: 900px) {
-  .share-toggle-button__strong {
-    font-size: 1.5rem;
+    transition: 0.1s opacity var(--transition-timing);
   }
 }

--- a/src/components/ShareToken/ShareToken.js
+++ b/src/components/ShareToken/ShareToken.js
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 import './ShareToken.css';
 
@@ -6,6 +6,7 @@ import { ReactComponent as ShareIcon } from '../../images/icon-share.svg';
 
 const ShareToken = ({ token }) => {
   const [showMobileShare, setShowMobileShare] = useState(false);
+  const [showDesktopShare, setShowDesktopShare] = useState(false);
   const shareTokenRef = useRef();
 
   function copyToken() {
@@ -16,9 +17,37 @@ const ShareToken = ({ token }) => {
 
   const handleTokenShare = () => {
     copyToken();
+
+    // toggle mobile token visibility
     setShowMobileShare(!showMobileShare);
-    shareTokenRef.current.focus();
+
+    // show token on desktop and direct focus to field
+    setShowDesktopShare(true);
   };
+
+  // when share area is shown, direct focus to field (important for screen readers to follow along)
+  useEffect(() => {
+    if (showMobileShare) shareTokenRef.current.focus();
+  }, [showMobileShare]);
+
+  /* this extra listener ensures the token is still hidden on click away if it's opened on a narrower/mobile 
+    view, then the user changes screen orientation or browser size to wider view. Otherwise it can get stuck 
+    open if the onBlur event on the text field has already happened.  */
+  useEffect(() => {
+    const handleTokenHide = (e) => {
+      if (!shareTokenRef.current.contains(e.target)) setShowDesktopShare(false);
+    };
+
+    if (showDesktopShare) {
+      // when share area is shown, direct focus to field (important for screen readers to follow along)
+      shareTokenRef.current.focus();
+      document.addEventListener('click', handleTokenHide);
+    }
+
+    return () => {
+      document.removeEventListener('click', handleTokenHide);
+    };
+  }, [showDesktopShare]);
 
   return (
     <>
@@ -26,9 +55,10 @@ const ShareToken = ({ token }) => {
         type="button"
         onClick={handleTokenShare}
         className="button list-header__share-toggle-button share-toggle-button"
-        aria-expanded={showMobileShare}
-        aria-controls="share-token"
-        aria-label="Share list"
+        aria-label={`${
+          showDesktopShare ? 'Copied to clipboard' : 'Share list'
+        }`}
+        aria-describedby="share-toke-hint"
       >
         <ShareIcon
           aria-hidden="true"
@@ -38,33 +68,40 @@ const ShareToken = ({ token }) => {
         <strong className="share-toggle-button__strong" htmlFor="shareToken">
           Share your list
         </strong>
-        <span className="share-toggle-button__hint">
-          Reveal your token and copy to clipboard.
-        </span>
       </button>
+
+      <span
+        className={`share-token-hint list-header__share-token-hint ${
+          !showDesktopShare ? 'share-token-hint_show' : ''
+        }`}
+        id="share-toke-hint"
+      >
+        Reveal your token and copy to clipboard.
+      </span>
 
       <div
         className={`share-token list-header__share-token ${
           showMobileShare ? 'share-token_mobile_show' : ''
-        }`}
+        } ${showDesktopShare ? 'share-token_desktop_show' : ''}`}
         id="share-token"
-        role="region"
-        tabIndex="-1"
-        ref={shareTokenRef}
       >
         <label className="share-token__label" htmlFor="shareToken">
           Your unique token:
         </label>
-        <div className="form-group clipboard-copy clipboard-copy">
-          <input
-            className="share-token__token text-field form-group__text-field"
-            type="text"
-            id="shareToken"
-            name="shareToken"
-            value={token}
-            readOnly
-          />
-        </div>
+        <input
+          className="share-token__token text-field"
+          type="text"
+          id="shareToken"
+          name="shareToken"
+          value={token}
+          ref={shareTokenRef}
+          onBlur={() => setShowDesktopShare(false)}
+          aria-describedby="token-copied"
+          readOnly
+        />
+        <span className="share-token__copied" id="token-copied">
+          Copied to clipboard!
+        </span>
       </div>
     </>
   );

--- a/src/components/ShareToken/ShareToken.js
+++ b/src/components/ShareToken/ShareToken.js
@@ -5,8 +5,7 @@ import './ShareToken.css';
 import { ReactComponent as ShareIcon } from '../../images/icon-share.svg';
 
 const ShareToken = ({ token }) => {
-  const [showMobileShare, setShowMobileShare] = useState(false);
-  const [showDesktopShare, setShowDesktopShare] = useState(false);
+  const [showShare, setShowShare] = useState(false);
   const shareTokenRef = useRef();
 
   function copyToken() {
@@ -17,37 +16,13 @@ const ShareToken = ({ token }) => {
 
   const handleTokenShare = () => {
     copyToken();
-
-    // toggle mobile token visibility
-    setShowMobileShare(!showMobileShare);
-
-    // show token on desktop and direct focus to field
-    setShowDesktopShare(true);
+    setShowShare(!showShare);
   };
 
-  // when share area is shown, direct focus to field (important for screen readers to follow along)
+  // when share area is shown, direct focus to field (helps screen readers follow along)
   useEffect(() => {
-    if (showMobileShare) shareTokenRef.current.focus();
-  }, [showMobileShare]);
-
-  /* this extra listener ensures the token is still hidden on click away if it's opened on a narrower/mobile 
-    view, then the user changes screen orientation or browser size to wider view. Otherwise it can get stuck 
-    open if the onBlur event on the text field has already happened.  */
-  useEffect(() => {
-    const handleTokenHide = (e) => {
-      if (!shareTokenRef.current.contains(e.target)) setShowDesktopShare(false);
-    };
-
-    if (showDesktopShare) {
-      // when share area is shown, direct focus to field (important for screen readers to follow along)
-      shareTokenRef.current.focus();
-      document.addEventListener('click', handleTokenHide);
-    }
-
-    return () => {
-      document.removeEventListener('click', handleTokenHide);
-    };
-  }, [showDesktopShare]);
+    if (showShare) shareTokenRef.current.focus();
+  }, [showShare]);
 
   return (
     <>
@@ -55,10 +30,10 @@ const ShareToken = ({ token }) => {
         type="button"
         onClick={handleTokenShare}
         className="button list-header__share-toggle-button share-toggle-button"
-        aria-label={`${
-          showDesktopShare ? 'Copied to clipboard' : 'Share list'
-        }`}
-        aria-describedby="share-toke-hint"
+        aria-label={`${showShare ? 'Hide List' : 'Share list'}`}
+        aria-expanded={showShare}
+        aria-controls="share-token"
+        aria-describedby="share-token-hint"
       >
         <ShareIcon
           aria-hidden="true"
@@ -66,24 +41,25 @@ const ShareToken = ({ token }) => {
           className="share-toggle-button__icon icon share-icon"
         />
         <strong className="share-toggle-button__strong" htmlFor="shareToken">
-          Share your list
+          {showShare ? 'Hide list token' : 'Share your list'}
         </strong>
       </button>
 
       <span
         className={`share-token-hint list-header__share-token-hint ${
-          !showDesktopShare ? 'share-token-hint_show' : ''
+          !showShare ? 'share-token-hint_show' : ''
         }`}
-        id="share-toke-hint"
+        id="share-token-hint"
       >
         Reveal your token and copy to clipboard.
       </span>
 
       <div
         className={`share-token list-header__share-token ${
-          showMobileShare ? 'share-token_mobile_show' : ''
-        } ${showDesktopShare ? 'share-token_desktop_show' : ''}`}
+          showShare ? 'share-token_show' : ''
+        }`}
         id="share-token"
+        aria-hidden={!showShare}
       >
         <label className="share-token__label" htmlFor="shareToken">
           Your unique token:
@@ -95,8 +71,8 @@ const ShareToken = ({ token }) => {
           name="shareToken"
           value={token}
           ref={shareTokenRef}
-          onBlur={() => setShowDesktopShare(false)}
           aria-describedby="token-copied"
+          focusable={showShare}
           readOnly
         />
         <span className="share-token__copied" id="token-copied">

--- a/src/components/ShareToken/ShareToken.js
+++ b/src/components/ShareToken/ShareToken.js
@@ -1,38 +1,30 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 
 import './ShareToken.css';
 
 import { ReactComponent as ShareIcon } from '../../images/icon-share.svg';
-import { ReactComponent as CopyIcon } from '../../images/icon-copy.svg';
-import { ReactComponent as CheckIcon } from '../../images/icon-checkbox.svg';
 
 const ShareToken = ({ token }) => {
   const [showMobileShare, setShowMobileShare] = useState(false);
-  const [copySuccess, setCopySuccess] = useState(false);
-  const [showDesktopShare, setDesktopShare] = useState(false);
+  const shareTokenRef = useRef();
 
   function copyToken() {
-    navigator.clipboard
-      .writeText(token)
-      .then(() => {
-        setCopySuccess(true);
-        setTimeout(() => setCopySuccess(false), 5000);
-      })
-      .catch((err) => {
-        document.execCommand(token); // possible fallback for older browsers
-        console.log(err);
-      });
+    navigator.clipboard.writeText(token).catch((err) => {
+      document.execCommand(token); // possible fallback for older browsers
+    });
   }
 
-  const showTokenDesktop = () => {
-    setDesktopShare(showDesktopShare ? false : true);
+  const handleTokenShare = () => {
+    copyToken();
+    setShowMobileShare(!showMobileShare);
+    shareTokenRef.current.focus();
   };
 
   return (
     <>
       <button
         type="button"
-        onClick={() => setShowMobileShare(!showMobileShare)}
+        onClick={handleTokenShare}
         className="button list-header__share-toggle-button share-toggle-button"
         aria-expanded={showMobileShare}
         aria-controls="share-token"
@@ -52,11 +44,13 @@ const ShareToken = ({ token }) => {
       </button>
 
       <div
-        className={`share-token list-header__share-token, share-token_desktop_show ${
+        className={`share-token list-header__share-token ${
           showMobileShare ? 'share-token_mobile_show' : ''
         }`}
         id="share-token"
         role="region"
+        tabIndex="-1"
+        ref={shareTokenRef}
       >
         <label className="share-token__label" htmlFor="shareToken">
           Your unique token:
@@ -70,26 +64,6 @@ const ShareToken = ({ token }) => {
             value={token}
             readOnly
           />
-          <button
-            type="button"
-            className={`share-token__copy-button ${
-              copySuccess ? 'share-token__copy-button_copied' : ''
-            } icon-only-button form-group__field-button`}
-            onClick={(e) => {
-              copySuccess ? e.preventDefault() : copyToken();
-            }}
-            aria-label={copySuccess ? 'Copied!' : 'Copy  to clipboard'}
-          >
-            {copySuccess ? (
-              <CheckIcon
-                aria-hidden="true"
-                focusable="false"
-                className="icon copied-icon"
-              />
-            ) : (
-              <CopyIcon aria-hidden="true" focusable="false" />
-            )}
-          </button>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Description

This PR changes the behaviour of the share token area so that it is hidden by default. 

When the button is clicked, it copies the token to the clipboard and focuses the user on the field containing the token (which is helpful for screenreaders). The button click also affects a state variable that control when to reveal the token visually and toggles the appropriate aria attributes.

## Related Issue

Closes #81 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
| ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### After

![Untitled Project](https://user-images.githubusercontent.com/67769490/131783410-f338bb01-038c-4e98-85a6-d6f163da979c.gif)

## Testing Steps / QA Criteria

1. Pull down branch, run npm start.
2. Check if the token is copied to your clipboard.
3. Check the token reveal on both narrow screen and wider screen.

