### PR TITLE
Fix home page bug with join form

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -82,11 +82,11 @@ function App() {
   }
 
   function joinList(shareToken) {
-    setToken(shareToken);
     return isTokenValid(shareToken).then((listExists) => {
       if (listExists) {
         setListId(listExists);
         localStorage.setItem('token', shareToken);
+        setToken(shareToken);
         return true;
       } else {
         setToken(null);


### PR DESCRIPTION
## Description

Fixes a bug on the homepage that causing joining the list to fail. Looks like this happened when merging the refactor of the join page form and the fixing of the home flash bug together.

## Related Issue

Closes #94 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |


## Testing Steps / QA Criteria

1. Try to join with an incorrect token. You should now see the normal errors.

